### PR TITLE
remove jquery-ui-bootstrap

### DIFF
--- a/change-theme.js
+++ b/change-theme.js
@@ -30,7 +30,7 @@ $(function() {
 	if (!localStorage.style) {
 		localStorage.style="Default";
 	}else{
-		changeThemeTo(localStorage.style)
+		changeThemeTo(localStorage.style);
 	}
 	/*if(!localStorage.navcolor){//change the color of navbars
 		localStorage.navcolor="vefault";

--- a/change-theme.js
+++ b/change-theme.js
@@ -21,16 +21,16 @@ var themes={
 function changeThemeTo(theme) {
 	localStorage.style=theme;
 	$("#theme").prop('disabled',true).prop('href',themes[theme]).prop('disabled',false);//change theme
+	//$(theme+"-theme").addClass()//an idea
 }
 $(function() {
   for(var i in themes) {
-		$(".theme-select").append($('<li><a onclick="changeThemeTo(\''+i+'\')">'+i+'</a></li>'));
+		$(".theme-select").append($('<li><a class="'+i+'-theme" onclick="changeThemeTo(\''+i+'\')">'+i+'</a></li>'));
 	}
 	if (!localStorage.style) {
 		localStorage.style="Default";
 	}else{
-		$(".theme-select").val(localStorage.style);
-		$("#theme").prop('disabled',true).prop('href',themes[$(".theme-select").val()]).prop('disabled',false);//change theme
+		changeThemeTo(localStorage.style)
 	}
 	/*if(!localStorage.navcolor){//change the color of navbars
 		localStorage.navcolor="vefault";

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,30 +6,10 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>AI.js demo</title>
 		
-		<!-- Le styles -->
-		<link href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/css/bootstrap.min.css" rel="stylesheet">
-		<link type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/css/custom-theme/jquery-ui-1.10.0.custom.css" rel="stylesheet" />
-		<link type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/css/font-awesome.min.css" rel="stylesheet" />
-		<!--[if IE 7]>
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/css/font-awesome-ie7.min.css">
-		<![endif]-->
-		<!--[if lt IE 9]>
-		<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/css/custom-theme/jquery.ui.1.10.0.ie.css"/>
-		<![endif]-->
-		<link href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/css/docs.css" rel="stylesheet">
-		<link href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/js/google-code-prettify/prettify.css" rel="stylesheet">
+		<!-- Latest compiled and minified CSS -->
 
-		<!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
-		<!--[if lt IE 9]>
-		<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-		<![endif]-->
-		
-		<!-- when I finally make the favicon, be smart and go to https://css-tricks.com/favicon-quiz/ for help-->
-		
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/assets/css/emojione.min.css" integrity="sha256-UZ7fDcAJctmoEcXmC5TPcZswNRqN/mLzj6uNS1GCVYs=" crossorigin="anonymous" />
-		<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 		<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" rel="stylesheet" id="theme">
-		
 		<link href="DemoCSS.css" rel="stylesheet">
 	</head>
 	<body style="padding-top:70px;padding-bottom:70px">
@@ -97,13 +77,7 @@
 		</noscript>
 		<!-- Placed at the end of the document so the pages load faster -->
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
-		
 		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-		
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/js/bootstrap.min.js" type="text/javascript"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/js/jquery-ui-1.10.0.custom.min.js" type="text/javascript"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/js/google-code-prettify/prettify.js" type="text/javascript"></script>
-
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/emojione/2.2.7/lib/js/emojione.min.js" integrity="sha256-9cBkVeU53NiJ9/BdcJta3HbERAmf5X9DE2WvL8V+gDs=" crossorigin="anonymous"></script>
 		<script src="../AI.js"></script>
 		<script src="../change-theme.js"></script>

--- a/index.html
+++ b/index.html
@@ -7,29 +7,9 @@
 		<script async defer src="https://buttons.github.io/buttons.js"></script>
 		<title>Ai.js homepage</title>
 		
-		<!-- Le styles -->
-		<link href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/css/bootstrap.min.css" rel="stylesheet">
-		<link type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/css/custom-theme/jquery-ui-1.10.0.custom.css" rel="stylesheet" />
-		<link type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/css/font-awesome.min.css" rel="stylesheet" />
-		<!--[if IE 7]>
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/css/font-awesome-ie7.min.css">
-		<![endif]-->
-		<!--[if lt IE 9]>
-		<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/css/custom-theme/jquery.ui.1.10.0.ie.css"/>
-		<![endif]-->
-		<link href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/css/docs.css" rel="stylesheet">
-		<link href="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/js/google-code-prettify/prettify.css" rel="stylesheet">
-
-		<!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
-		<!--[if lt IE 9]>
-		<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-		<![endif]-->
-		
-		<!-- when I finally make the favicon, be smart and go to https://css-tricks.com/favicon-quiz/ for help-->
-		
-		<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+		<!-- Latest compiled and minified CSS -->
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 		<link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" rel="stylesheet" id="theme">
-		
 	</head>
 	<body style="padding-top:70px">
 		<a class="sr-only sr-only-focusable" href="#content">Skip to main content</a>
@@ -73,16 +53,9 @@
 			<a class="github-button" href="https://github.com/lazerbeak12345/AI.js/fork" data-icon="octicon-repo-forked" data-style="mega" data-count-href="/lazerbeak12345/AI.js/network" data-count-api="/repos/lazerbeak12345/AI.js#forks_count" data-count-aria-label="# forks on GitHub" aria-label="Fork lazerbeak12345/AI.js on GitHub">Fork</a>
 			<a class="github-button" href="https://github.com/lazerbeak12345/AI.js/issues" data-icon="octicon-issue-opened" data-style="mega" data-count-api="/repos/lazerbeak12345/AI.js#open_issues_count" data-count-aria-label="# issues on GitHub" aria-label="Issue lazerbeak12345/AI.js on GitHub">Issue</a>
 		</div>
-		<!--a style="position: relative; top: 0; border: 0; right: 0;" target="_blank" href="https://github.com/Lazerbeak12345/AI.js" class="github-corner" aria-label="View source on Github" title="View source on Github"><svg width="80" height="80" viewBox="0 0 250 250" style="fill:#151513; color:#fff; position: fixed; top: 0; border: 0; right: 0;" aria-hidden="true"><path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path><path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2" fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path><path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z" fill="currentColor" class="octo-body"></path></svg></a><style>.github-corner:hover .octo-arm{animation:octocat-wave 560ms ease-in-out}@keyframes octocat-wave{0%,100%{transform:rotate(0)}20%,60%{transform:rotate(-25deg)}40%,80%{transform:rotate(10deg)}}@media (max-width:500px){.github-corner:hover .octo-arm{animation:none}.github-corner .octo-arm{animation:octocat-wave 560ms ease-in-out}}</style><!---->
 		<!-- Placed at the end of the document so the pages load faster -->
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha256-hVVnYaiADRTO2PzUGmuLJr8BLUSjGIZsDYGmIJLv2b8=" crossorigin="anonymous"></script>
-		
 		<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-		
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/js/bootstrap.min.js" type="text/javascript"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/js/jquery-ui-1.10.0.custom.min.js" type="text/javascript"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-bootstrap/0.5pre/assets/js/google-code-prettify/prettify.js" type="text/javascript"></script>
-		
 		<script src="change-theme.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Here's why:
- It didn't work for every theme
- I couldn't tell if jqui was the original and jquery-ui-bootstrap was the illegal copy or if it was the other way around
- They could have simply used sass to be 1 million times faster then what they were doing.
- They were still stuck at bootstrap v2 and I am making the switch to bootstrap v4 from v3
- I am making a better solution
- And lastly-but most importantly I DONT NEED JQUERY UI FOR THIS PROGECT